### PR TITLE
Add additional pricing helpers (find reserves inversely with given price, and the RAY variants)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ This function is used internally by `genAddress` but is exposed in case it is us
 
 Given a curve point indicated by two reserve values, returns the marginal price on the curve at this point. The price is returned as a `10**18` scaled fraction.
 
+### `getCurrentPriceRAY(params, reserve0, reserve1)`
+
+Given a curve point indicated by two reserve values, returns the marginal price on the curve at this point. The price is returned as a `10**27` scaled fraction.
+
+### `getCurrentReserves(params, currentPrice)`
+
+Given a marginal price for a point on the curve, returns the two reserves of that point. The price input is a `10**18` scaled fraction.
+
+### `getCurrentReservesRAY(params, currentPriceRAY)`
+
+Given a marginal price for a point on the curve, returns the two reserves of that point. The price input is a `10**27` scaled fraction.
+
 ### `verifyPoint(params, reserve0, reserve1)`
 
 Returns true if the point is on or above the curve specified by `params`. If true, it means that the EulerSwap contract would accept this point as a valid point after a swap.
@@ -83,6 +95,10 @@ Verifies that point `(x, y)` is on or above the curve.
 ### `df_dx(x, px, py, x0, cx)`
 
 The derivative of `f()`. Useful for computing the marginal price at given curve points.
+
+### `df_dx_RAY(x, px, py, x0, cx)`
+
+The derivative of `f()`. Useful for computing the marginal price at given curve points. The output is a `10**27` scaled fraction.
 
 ### `fInverse(y, px, py, x0, y0, cx)`
 

--- a/src/LibEulerSwap.js
+++ b/src/LibEulerSwap.js
@@ -4,6 +4,8 @@ import { generatePrivateKey } from 'viem/accounts';
 import iEulerSwapAbi from './IEulerSwap.json';
 
 const c1e18 = 10n**18n;
+const c1e27 = 10n ** 27n;
+const c1e9 = 10n ** 9n;
 const paramsAbi = iEulerSwapAbi.abi.find(item => item.name === 'getParams').outputs;
 
 
@@ -64,6 +66,136 @@ export function getCurrentPrice(params, reserve0, reserve1) {
     }
 
     return price;
+}
+
+export function getCurrentPriceRAY(params, reserve0, reserve1) {
+    let price;
+
+    if (reserve0 <= params.equilibriumReserve0) {
+        if (reserve0 === params.equilibriumReserve0) return (params.priceX * c1e27) / params.priceY;
+        price = -df_dx_RAY(reserve0, params.priceX, params.priceY, params.equilibriumReserve0, params.concentrationX);
+    } else {
+        if (reserve1 === params.equilibriumReserve1) return (params.priceY * c1e27) / params.priceX;
+        price = -df_dx_RAY(reserve1, params.priceY, params.priceX, params.equilibriumReserve1, params.concentrationY);
+        price = (c1e27 * c1e27) / price;
+    }
+    return price;
+}
+
+export function getCurrentReserves(params, currentPrice) {
+    const {
+        priceX: px,
+        priceY: py,
+        equilibriumReserve0: x0,
+        equilibriumReserve1: y0,
+        concentrationX: cx,
+        concentrationY: cy,
+    } = params;
+
+    const apexPrice = (px * c1e18) / py;
+    if (currentPrice < apexPrice) throw new Error('price is below apex - no curve solution');
+    if (currentPrice === apexPrice) return [x0, y0];
+
+    const searchLeft = () => {
+        let lo = 1n;
+        let hi = x0;
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1n;
+            const y = f(mid, px, py, x0, y0, cx);
+            const p = getCurrentPrice(params, mid, y);
+            if (p === currentPrice) return [mid, y];
+            if (p > currentPrice) {
+                lo = mid + 1n;
+            } else {
+                hi = mid - 1n;
+            }
+        }
+        return undefined;
+    };
+
+    const searchRight = () => {
+        let lo = y0;
+        let hi = y0;
+        while (true) {
+            const xAtHi = f(hi, py, px, y0, x0, cy);
+            const p = getCurrentPrice(params, xAtHi, hi);
+            if (p >= currentPrice) break;
+            hi <<= 1n;
+        }
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1n;
+            const x = f(mid, py, px, y0, x0, cy);
+            const p = getCurrentPrice(params, x, mid);
+            if (p === currentPrice) return [x, mid];
+            if (p < currentPrice) {
+                lo = mid + 1n;
+            } else {
+                hi = mid - 1n;
+            }
+        }
+        return undefined;
+    };
+
+    const left = searchLeft();
+    if (left) return left;
+    const right = searchRight();
+    if (right) return right;
+    throw new Error('no integer reserves produce the supplied price');
+}
+
+export function getCurrentReservesRAY(params, currentPriceRAY) {
+    const {
+        priceX: px,
+        priceY: py,
+        equilibriumReserve0: x0,
+        equilibriumReserve1: y0,
+        concentrationX: cx,
+        concentrationY: cy,
+    } = params;
+
+    const apexPriceRAY = (px * c1e27) / py;
+    if (currentPriceRAY < apexPriceRAY) throw new Error('price below apex - no curve solution');
+    if (currentPriceRAY === apexPriceRAY) return [x0, y0];
+
+    const searchLeft = () => {
+        let lo = 1n,
+            hi = x0;
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1n;
+            const y = f(mid, px, py, x0, y0, cx);
+            const p = getCurrentPriceRAY(params, mid, y);
+            if (p === currentPriceRAY) return [mid, y];
+            if (p > currentPriceRAY) lo = mid + 1n;
+            else hi = mid - 1n;
+        }
+        return undefined;
+    };
+
+    const searchRight = () => {
+        let lo = y0,
+            hi = y0;
+        while (true) {
+            const xAtHi = f(hi, py, px, y0, x0, cy);
+            const p = getCurrentPriceRAY(params, xAtHi, hi);
+            if (p >= currentPriceRAY) break;
+            hi <<= 1n;
+        }
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1n;
+            const x = f(mid, py, px, y0, x0, cy);
+            const p = getCurrentPriceRAY(params, x, mid);
+            if (p === currentPriceRAY) return [x, mid];
+            if (p < currentPriceRAY) lo = mid + 1n;
+            else hi = mid - 1n;
+        }
+        return undefined;
+    };
+
+    const left = searchLeft();
+    if (left) return left;
+    const right = searchRight();
+    if (right) return right;
+    throw new Error('no integer reserves produce the supplied RAY price');
 }
 
 export function verifyPoint(params, reserve0, reserve1) {
@@ -185,6 +317,11 @@ export function verify(x, y, px, py, x0, y0, cx, cy) {
 export function df_dx(x, px, py, x0, cx) {
     const r = (((x0 * x0) / x) * c1e18) / x;
     return (-px * (cx + ((c1e18 - cx) * r) / c1e18)) / py;
+}
+
+export function df_dx_RAY(x, px, py, x0, cx) {
+    const r = (((x0 * x0) / x) * c1e18) / x;
+    return (-px * c1e9 * (cx + ((c1e18 - cx) * r) / c1e18)) / py;
 }
 
 function computeScale(x) {

--- a/src/LibEulerSwap.js
+++ b/src/LibEulerSwap.js
@@ -158,8 +158,8 @@ export function getCurrentReservesRAY(params, currentPriceRAY) {
     if (currentPriceRAY === apexPriceRAY) return [x0, y0];
 
     const searchLeft = () => {
-        let lo = 1n,
-            hi = x0;
+        let lo = 1n;
+        let hi = x0;
         while (lo <= hi) {
             const mid = (lo + hi) >> 1n;
             const y = f(mid, px, py, x0, y0, cx);
@@ -172,8 +172,8 @@ export function getCurrentReservesRAY(params, currentPriceRAY) {
     };
 
     const searchRight = () => {
-        let lo = y0,
-            hi = y0;
+        let lo = y0;
+        let hi = y0;
         while (true) {
             const xAtHi = f(hi, py, px, y0, x0, cy);
             const p = getCurrentPriceRAY(params, xAtHi, hi);


### PR DESCRIPTION
This PR adds 4 functions that are helpful for off-chain analysis and the frontend.

- `getCurrentPriceRAY` - Calculates the marginal price of y/x given a point on the curve - but in 27 decimals (RAY) precision! This is needed in order to more accurately represent the prices in some scenarios like an asset with USD price $0.0001, paired with an 8-decimal and expensive asset like WBTC.
- `getCurrentReserves` - Inversely finds the point on curve (reserve0, reserve1) given a marginal price of y/x, by doing a binary search. I'm pretty sure it can be solved analytically but I suck at math, and the runtime of binary search seems pretty fair (essentially on a subset of 256-bit space), plus the algo is typically used to run only once and off-chain - like to find a specific point on a chart on a frontend app.
- `getCurrentReservesRAY` - Same as `getCurrentReserves` but the price input now is in RAY.
- `df_dx_RAY` - Same as the existing `df_dx` but the output now is in RAY.