### PR TITLE
Fix `fInverse`

### DIFF
--- a/src/LibEulerSwap.js
+++ b/src/LibEulerSwap.js
@@ -233,7 +233,7 @@ function bigintCeil(x) {
 }
 
 export function fInverse(y, px, py, x0, y0, cx) {
-    const term1 = (((py * c1e18 * (y - y0)) / px) * c1e18) / px;
+    const term1 = (py * c1e18 * (y - y0)) / px;
     const term2 = (2n * cx - c1e18) * x0;
     const B = (term1 - term2) / c1e18;
     const C = ((c1e18 - cx) * x0 * x0) / c1e18;
@@ -258,7 +258,7 @@ export function fInverse(y, px, py, x0, y0, cx) {
 
     let x = 0n;
     if (B <= 0n) {
-        x = (absB + sqrt) / 2n + 1n;
+        x = ((absB + sqrt) * 10n ** 18n) / (2n * cx) + 1n;
     } else {
         x = bigintCeil((2n * C) / (absB + sqrt)) + 1n;
     }

--- a/src/LibEulerSwap.js
+++ b/src/LibEulerSwap.js
@@ -233,11 +233,11 @@ function bigintCeil(x) {
 }
 
 export function fInverse(y, px, py, x0, y0, cx) {
-    const term1 = (py * c1e18 * (y - y0)) / px;
+    const term1 = mulDivCeil(py * c1e18, y - y0, px);
     const term2 = (2n * cx - c1e18) * x0;
     const B = (term1 - term2) / c1e18;
-    const C = ((c1e18 - cx) * x0 * x0) / c1e18;
-    const fourAC = (4n * cx * C) / c1e18;
+    const C = mulDivCeil((c1e18 - cx), x0 * x0, c1e18);
+    const fourAC = mulDivCeil(4n * cx, C, c1e18);
 
     const absB = B >= 0n ? B : -B;
 
@@ -250,7 +250,7 @@ export function fInverse(y, px, py, x0, y0, cx) {
         sqrt = bigintSqrt(discriminant);
     } else {
         const scale = computeScale(absB);
-        squaredB = ((absB / scale) * absB) / scale;
+        squaredB = mulDivCeil(absB / scale, absB, scale);
         discriminant = squaredB + fourAC / (scale * scale);
         sqrt = bigintSqrt(discriminant);
         sqrt = sqrt * scale;
@@ -258,7 +258,7 @@ export function fInverse(y, px, py, x0, y0, cx) {
 
     let x = 0n;
     if (B <= 0n) {
-        x = ((absB + sqrt) * 10n ** 18n) / (2n * cx) + 1n;
+        x = mulDivCeil((absB + sqrt), c1e18, 2n * cx) + 1n;
     } else {
         x = bigintCeil((2n * C) / (absB + sqrt)) + 1n;
     }
@@ -268,4 +268,8 @@ export function fInverse(y, px, py, x0, y0, cx) {
     }
 
     return x;
+}
+
+function mulDivCeil(x, y, denominator) {
+    return (x * y + denominator - 1n) / denominator;
 }


### PR DESCRIPTION
The current version of the `fInverse` seems to have a bug. This PR should fix it and makes it 1:1 faithful to [CurveLib.sol](https://github.com/euler-xyz/euler-swap/blob/7080c3fe0c9f935c05849a0756ed43d959130afd/src/libraries/CurveLib.sol#L58).

The main issue is the `term1` and the line `x = (absB + sqrt) / 2n + 1n`. To make it 1:1 faithful to the Solidity code, I also updated the square root function to be rounding up, and added another 2 utils `mulDivCeil` and `ceilDiv`.

A scenario to test:

We choose the following curve params because this can be easily plotted using the desmos visualizer:

```typescript
const SAMPLE_CURVE_PARAMS: CurveParams = {
    priceX: 1_000n * 10n ** 15n, // 1
    priceY: 1_300n * 10n ** 15n, // 1.3
    equilibriumReserve0: 100n * 10n ** 18n, // 100
    equilibriumReserve1: 170n * 10n ** 18n, // 170
    concentrationX: 8n * 10n ** 17n, // 0.8
    concentrationY: 1n * 10n ** 17n, // 0.1
};
```

We try to find the `y` reserve for an `x = 350` with `x > x0`, so it lands on the right side of the equilibrium and requires `fInverse` with switched-around params to calculate the `y`.

To call the Solidity version of the `fInverse` with the params above, try this with [chisel](https://getfoundry.sh/chisel/overview/):
```solidity
import {CurveLib} from "euler-swap/src/libraries/CurveLib.sol";

uint y = CurveLib.fInverse(350000000000000000000,1300000000000000000,1000000000000000000,170000000000000000000,100000000000000000000,100000000000000000);
```

This yields output:
```
Type: uint256
├ Hex: 0x43223182875bc97d5
├ Hex (full word): 0x0000000000000000000000000000000000000000000000043223182875bc97d5
└ Decimal: 77399734182972528597
```

To call the current/incorrect JS version of the `fInverse`:
```typescript
const y = fInverse(350000000000000000000n,1300000000000000000n,1000000000000000000n,170000000000000000000n,100000000000000000000n,100000000000000000n);
console.log(y);
```

This yields output:
```
88828377717060349937n
```

After applying the fix in this PR, the output becomes:
```
77399734182972528597n
```